### PR TITLE
Removed Depricated _t() Priority

### DIFF
--- a/code/InvisibleSpamProtectorField.php
+++ b/code/InvisibleSpamProtectorField.php
@@ -69,8 +69,7 @@ class InvisibleSpamProtectorField extends FormField {
 				$this->name,
 				_t(
 					'InvisibleSpamProtectionField.FIELDNOTEMPTY',
-					"Anti-spam field is not empty. Please leave field unchanged.",
-					PR_MEDIUM
+					"Anti-spam field is not empty. Please leave field unchanged."
 				),
 				"error"
 			);


### PR DESCRIPTION
Caused following depreciation message:
````[User Deprecated] The $priority argument to _t() is deprecated, please use module inclusion priorities instead. Called from _t.````