### PR TITLE
Fixes CSS Location for Composer

### DIFF
--- a/code/InvisibleSpamProtectorField.php
+++ b/code/InvisibleSpamProtectorField.php
@@ -35,7 +35,11 @@ class InvisibleSpamProtectorField extends FormField {
 	 * @return HTML
 	 */
 	function Field($properties = array()) {
-		Requirements::css("InvisibleSpamProtection/css/InvisibleSpamProtector.css");
+		if (Director::fileExists("silverstripe-invisible-spam-protection")) {
+			Requirements::css("silverstripe-invisible-spam-protection/css/InvisibleSpamProtector.css");
+		} else {
+			Requirements::css("InvisibleSpamProtection/css/InvisibleSpamProtector.css");
+		}
 
 		if(self::showAntiSpam()) {
 			$attributes = array(


### PR DESCRIPTION
When using Composer to install the module, the module directory is called ````silverstripe-invisible-spam-protection```` and not ````InvisibleSpamProtection````. This was causing the CSS to fail to be included when installed via Composer. 

This update first checks if ````silverstripe-invisible-spam-protection```` exists and uses the CSS there if so, if not, it reverts to the CSS in ````InvisibleSpamProtection````.